### PR TITLE
Check that boundary nets are connected to a physical pin and nothing else.

### DIFF
--- a/src/arachne-pnr.cc
+++ b/src/arachne-pnr.cc
@@ -486,6 +486,7 @@ main(int argc, const char **argv)
 
   *logs << "prune...\n";
   d->prune();
+  d->check_boundary_nets();
 #ifndef NDEBUG
   d->check();
 #endif

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -498,7 +498,7 @@ Model::check_boundary_nets(const Design *d) const
         continue;
 
       bool is_boundary_net = false;
-      Port * physical_port;
+      Port *physical_port = nullptr;
 
       for(auto i = n->connections().begin(); i != n->connections().end(); ++i)
         {

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -467,6 +467,63 @@ Model::add_instance(Model *inst_of)
   return new_inst;
 }
 
+bool Model::is_physical_port(Models &models, const Port *p) const
+{
+  bool is_physical_port = p
+                         && isa<Instance>(p->node())
+                         && ((models.is_tbuf(cast<Instance>(p->node()))
+                                && p->name() == "Y")
+                             || (models.is_ioX(cast<Instance>(p->node()))
+                                && p->name() == "PACKAGE_PIN")
+                             || (models.is_pllX(cast<Instance>(p->node()))
+                                && p->name() == "PACKAGEPIN")
+                             || (models.is_rgba_drv(cast<Instance>(p->node()))
+                                && (p->name() == "RGB0" || p->name() == "RGB1" || p->name() == "RGB2"))
+                            );
+
+  return is_physical_port;
+}
+
+// Check that ports which are connected to physical port are
+// connected to that port only
+void
+Model::check_boundary_nets(const Design *d) const
+{
+  Models models(d);
+
+  for (Port *p : m_ordered_ports)
+    {
+      Net *n = p->connection();
+      if (!n)
+        continue;
+
+      bool is_boundary_net = false;
+      Port * physical_port;
+
+      for(auto i = n->connections().begin(); i != n->connections().end(); ++i)
+        {
+          Port *q = *i;
+          if (p == q)
+            continue;
+
+          if (is_physical_port(models, q))
+            {
+              if (is_boundary_net)
+                fatal(fmt("Top level port '" << p->name() << "' assigned to multiple IO pads: '" <<
+                          physical_port->name() << "' and '" << q->name() << "'"));
+
+              is_boundary_net = true;
+              physical_port = q;
+            }
+        }
+
+      if (is_boundary_net && n->connections().size() != 2)
+        fatal(fmt("Top level port '" << p->name() << "' assigned to an IO pad '" << physical_port->name() << 
+                  "' and internal nodes"));
+
+    }
+}
+
 std::set<Net *, IdLess>
 Model::boundary_nets(const Design *d) const
 {
@@ -1504,11 +1561,17 @@ Design::prune()
     p.second->prune();
 }
 
+void
+Design::check_boundary_nets() const
+{
+  m_top->check_boundary_nets(this);
+}
+
 #ifndef NDEBUG
 void
 Design::check() const
 {
-   m_top->check(this);
+  m_top->check(this);
 }
 #endif
 

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -1510,6 +1510,7 @@ Design::check() const
 {
    m_top->check(this);
 }
+#endif
 
 void
 Design::write_blif(std::ostream &s) const

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -535,17 +535,7 @@ Model::boundary_nets(const Design *d) const
       if (n)
         {
           Port *q = p->connection_other_port();
-          if (q
-              && isa<Instance>(q->node())
-              && ((models.is_tbuf(cast<Instance>(q->node()))
-                      && q->name() == "Y")
-                  || (models.is_ioX(cast<Instance>(q->node()))
-                      && q->name() == "PACKAGE_PIN")
-                  || (models.is_pllX(cast<Instance>(q->node()))
-                      && q->name() == "PACKAGEPIN")
-                  || (models.is_rgba_drv(cast<Instance>(q->node()))
-                      && (q->name() == "RGB0" || q->name() == "RGB1" || q->name() == "RGB2")
-                  )))
+          if (is_physical_port(models, q))
             extend(bnets, n);
         }
     }
@@ -689,16 +679,7 @@ Model::check(const Design *d) const
           if (n)
             {
               Port *q = p->connection_other_port();
-              assert (q
-                      && isa<Instance>(q->node())
-                      && ((models.is_tbuf(cast<Instance>(q->node()))
-                              && q->name() == "Y")
-                          || (models.is_ioX(cast<Instance>(q->node()))
-                              && q->name() == "PACKAGE_PIN")
-                          || (models.is_pllX(cast<Instance>(q->node()))
-                              && q->name() == "PACKAGEPIN")
-                          || (models.is_rgba_drv(cast<Instance>(q->node())) 
-                            &&  (q->name() == "RGB0" || q->name() == "RGB1" || q->name() == "RGB2"))));
+              assert(is_physical_port(models, q));
             }
         }
     }

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -469,7 +469,7 @@ Model::add_instance(Model *inst_of)
 
 bool Model::is_physical_port(Models &models, const Port *p) const
 {
-  bool is_physical_port = p
+  bool is_phys_port = p
                          && isa<Instance>(p->node())
                          && ((models.is_tbuf(cast<Instance>(p->node()))
                                 && p->name() == "Y")
@@ -481,7 +481,7 @@ bool Model::is_physical_port(Models &models, const Port *p) const
                                 && (p->name() == "RGB0" || p->name() == "RGB1" || p->name() == "RGB2"))
                             );
 
-  return is_physical_port;
+  return is_phys_port;
 }
 
 // Check that ports which are connected to physical port are

--- a/src/netlist.cc
+++ b/src/netlist.cc
@@ -1508,10 +1508,8 @@ Design::prune()
 void
 Design::check() const
 {
-  for (const auto &p : m_models)
-    p.second->check(this);
+   m_top->check(this);
 }
-#endif
 
 void
 Design::write_blif(std::ostream &s) const

--- a/src/netlist.hh
+++ b/src/netlist.hh
@@ -30,6 +30,7 @@ class Port;
 class Node;
 class Instance;
 class Model;
+class Models;
 class Design;
 
 class Identified
@@ -369,6 +370,8 @@ public:
   
   bool has_param(const std::string &pn) { return contains_key(m_params, pn); }
   
+  bool is_physical_port(Models &models, const Port *p) const;
+  void check_boundary_nets(const Design *d) const;
   std::set<Net *, IdLess> boundary_nets(const Design *d) const;
   std::pair<std::vector<Net *>, std::map<Net *, int, IdLess>>
     index_nets() const;
@@ -411,6 +414,7 @@ public:
   void write_verilog(std::ostream &s) const;
   void write_blif(std::ostream &s) const;
   void dump() const;
+  void check_boundary_nets() const;
 #ifndef NDEBUG
   void check() const;
 #endif


### PR DESCRIPTION
The 'boundary_nets' method uses 'connection_other_port' to check if a net is connected to a physical pin:
https://github.com/cseed/arachne-pnr/blob/5d830dd94ad956d17d77168fe7718f22f8b55b33/src/netlist.cc#L480

However, this method assumes that there are a maximum of 2 ports connected to the net.

When a netlist is given that violates this assumption, the net is not listed as a boundary net which will result in internal check failures later on.

This commit adds a 'check_boundary_nets' method that ensures that boundary nets meet the expectations. If they do not, it fails gracefully.

This commit fixes both issue #77 and #100.

Tom
